### PR TITLE
Bump Ruby version to > 2.0

### DIFF
--- a/wkhtmltopdf-binary.gemspec
+++ b/wkhtmltopdf-binary.gemspec
@@ -5,8 +5,8 @@ Gem::Specification.new do |s|
   s.summary = 'Provides binaries for WKHTMLTOPDF project in an easily accessible package.'
   s.description = ''
 
-  s.required_ruby_version = '>= 1.8.7'
-  s.required_rubygems_version = ">= 1.3.6"
+  s.required_ruby_version = '> 2.0.0'
+  s.required_rubygems_version = "> 1.3.6"
 
   s.author = '- Research Information Systems, The University of Iowa'
   s.homepage = ''


### PR DESCRIPTION
This was not compiling OMM when the Ruby version was 1.8.7. I set the branch in the gemfile OMM to this branch and it is compiling correctly during bundle.
